### PR TITLE
Replace Vec3f by Vec3r for consistency with polylib

### DIFF
--- a/include/CutInfo/CutNormalArray.h
+++ b/include/CutInfo/CutNormalArray.h
@@ -160,7 +160,7 @@ public:
 #endif
     normalData = new Normal[nNormal];
     for (int i = 0; i < nNormal; i++) {
-      Vec3f n = tList[i]->get_normal();
+      Vec3r n = tList[i]->get_normal();
       normalData[i][0] = n[0];
       normalData[i][1] = n[1];
       normalData[i][2] = n[2];

--- a/src/CutSearch.cpp
+++ b/src/CutSearch.cpp
@@ -25,8 +25,8 @@ void CutSearch::search(const double center[], const double range[],
                        double pos6[], BidType bid6[],
                        Triangle* tri6[]) const
 {
-  Vec3f min(center[X]-range[X_M], center[Y]-range[Y_M], center[Z]-range[Z_M]);
-  Vec3f max(center[X]+range[X_P], center[Y]+range[Y_P], center[Z]+range[Z_P]);
+  Vec3r min(center[X]-range[X_M], center[Y]-range[Y_M], center[Z]-range[Z_M]);
+  Vec3r max(center[X]+range[X_P], center[Y]+range[Y_P], center[Z]+range[Z_P]);
 
   clearCutInfo(range, pos6, bid6, tri6);
 

--- a/src/Cutlib.cpp
+++ b/src/Cutlib.cpp
@@ -327,11 +327,11 @@ CutlibReturn CalcCutInfoOctreeAllCell(SklTree* tree, const Polylib* pl,
     for (size_t j = 0; j < ny; j++) {
       for (size_t i = 0; i < nx; i++) {
         SklCell* rootCell = tree->GetRootCell(i, j, k);
-        Vec3f org, d;
+        Vec3r org, d;
         rootCell->GetOrigin(org[0], org[1], org[2]);
         rootCell->GetPitch(d[0], d[1], d[2]);
-        Vec3f min = org - 0.5 * d;
-        Vec3f max = org + 1.5 * d;
+        Vec3r min = org - 0.5 * d;
+        Vec3r max = org + 1.5 * d;
 
         cutOctree::CutTriangles ctList;
         cutOctree::CutTriangle::AppendCutTriangles(ctList, pl, pgList, min, max);

--- a/src/RepairPolygonData.cpp
+++ b/src/RepairPolygonData.cpp
@@ -27,8 +27,8 @@ void repairPolygons(PolygonGroup *pg,
     if (doubt_normal_quality) reset = true;
 
     if (doubt_vertex_order) {
-      Vec3f normal0 = (*p)->get_normal();
-      Vec3f normal = cross(*vertex0[1]-*vertex0[0], *vertex0[2]-*vertex0[0]); 
+      Vec3r normal0 = (*p)->get_normal();
+      Vec3r normal = cross(*vertex0[1]-*vertex0[0], *vertex0[2]-*vertex0[0]); 
       if (dot(normal, normal0) < 0.0) {
         // 節点1と節点2を入れ替え
         vertex[1] = vertex0[2];  


### PR DESCRIPTION
Polylib を --with-real=double 付きでコンパイルした場合に，
Vec3f と Vec3<PL_REAL> で型の不整合が生じたため．
